### PR TITLE
Workflow checkout version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Semantic Release
         uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
Update the workflow actions/checkout version from v3 to v4 to avoid deprecated Node.js version.